### PR TITLE
Log out user when access token expires

### DIFF
--- a/src/app/console/[appId]/api-keys/page.tsx
+++ b/src/app/console/[appId]/api-keys/page.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/lib/server/api-keys";
 import { getChallenges } from "@/lib/server/challenge";
 import { getApplications } from "@/lib/server/console";
-import { getAccessToken } from "@auth0/nextjs-auth0";
+import { getAccessTokenOrLogout } from "@/lib/server/auth";
 
 export const dynamic = "force-dynamic";
 
@@ -17,7 +17,7 @@ export default async function ApiKeysPage({
 }: {
   params: { appId: string };
 }) {
-  const accessToken = (await getAccessToken()).accessToken!!;
+  const accessToken = await getAccessTokenOrLogout();
   const apps = await getApplications(accessToken);
   const challenges = await getChallenges(accessToken);
   const keysByApp = await Promise.all(

--- a/src/app/console/[appId]/challenge-preferences/page.tsx
+++ b/src/app/console/[appId]/challenge-preferences/page.tsx
@@ -4,7 +4,7 @@ import {
   updateChallengePreferences,
 } from "@/lib/server/challenge-preferences";
 import { ChallengePreferences } from "@/lib/server/types";
-import { getAccessToken } from "@auth0/nextjs-auth0";
+import { getAccessTokenOrLogout } from "@/lib/server/auth";
 
 export const dynamic = "force-dynamic";
 
@@ -13,7 +13,7 @@ export default async function ChallengePreferencesPage({
 }: {
   params: { appId: string };
 }) {
-  const accessToken = (await getAccessToken()).accessToken!!;
+  const accessToken = await getAccessTokenOrLogout();
   const preferences = await getChallengePreferences(accessToken, params.appId);
 
   async function handleUpdatePreferences(

--- a/src/app/console/[appId]/layout.tsx
+++ b/src/app/console/[appId]/layout.tsx
@@ -2,7 +2,7 @@ import Sidebar from "@/components/sidebar/Sidebar";
 import Topbar from "@/components/topbar/Topbar";
 import { SidebarProvider } from "@/components/sidebar/SidebarContext";
 import { getApplications } from "@/lib/server/console";
-import { getAccessToken } from "@auth0/nextjs-auth0";
+import { getAccessTokenOrLogout } from "@/lib/server/auth";
 import { redirect } from "next/navigation";
 
 export default async function DashboardLayout({
@@ -12,8 +12,8 @@ export default async function DashboardLayout({
   children: React.ReactNode;
   params: { appId: string };
 }) {
-  const tokenRes = await getAccessToken();
-  const apps = await getApplications(tokenRes.accessToken!!);
+  const accessToken = await getAccessTokenOrLogout();
+  const apps = await getApplications(accessToken);
   if (apps.length === 0 || !apps.some((a) => a.id === params.appId)) {
     return redirect("/console");
   }

--- a/src/app/console/[appId]/page.tsx
+++ b/src/app/console/[appId]/page.tsx
@@ -1,13 +1,13 @@
 import { createApplication, getApplications } from "@/lib/server/console";
 import ApplicationCard from "@/components/console/ApplicationCard";
-import { getAccessToken } from "@auth0/nextjs-auth0";
+import { getAccessTokenOrLogout } from "@/lib/server/auth";
 import { PlusIcon } from "@heroicons/react/24/outline";
 
 export const dynamic = "force-dynamic";
 
 export default async function ConsolePage() {
-  const tokenRes = await getAccessToken();
-  const apps = await getApplications(tokenRes.accessToken!!);
+  const accessToken = await getAccessTokenOrLogout();
+  const apps = await getApplications(accessToken);
 
   async function handleSubmit(form: FormData) {
     "use server";

--- a/src/app/console/page.tsx
+++ b/src/app/console/page.tsx
@@ -2,11 +2,11 @@ import { getApplications, createApplication } from "@/lib/server/console";
 import { redirect } from "next/navigation";
 import { PlusIcon } from "@heroicons/react/24/outline";
 import Image from "next/image";
-import { getAccessToken } from "@auth0/nextjs-auth0";
+import { getAccessTokenOrLogout } from "@/lib/server/auth";
 
 export default async function WelcomeConsolePage() {
-  const tokenRes = await getAccessToken();
-  const appsList = await getApplications(tokenRes.accessToken!!);
+  const accessToken = await getAccessTokenOrLogout();
+  const appsList = await getApplications(accessToken);
   if (appsList.length > 0) {
     redirect(`/console/${appsList[0].id}`);
   }

--- a/src/lib/server/api-keys.ts
+++ b/src/lib/server/api-keys.ts
@@ -2,7 +2,7 @@
 
 import { revalidateTag, unstable_cache } from "next/cache";
 import { ApiKey, ApiKeyUnstable } from "./types";
-import { getAccessToken } from "@auth0/nextjs-auth0";
+import { getAccessTokenOrLogout } from "./auth";
 import env from "./env";
 
 export const getApiKeysUnstable = async (
@@ -50,7 +50,7 @@ export async function generateApiKey(appId: string) {
   await fetch(`${env.GOTCHA_ORIGIN}/api/console/${appId}/api-key`, {
     method: "POST",
     headers: {
-      Authorization: `Bearer ${(await getAccessToken()).accessToken}`,
+      Authorization: `Bearer ${await getAccessTokenOrLogout()}`,
     },
   });
 
@@ -71,7 +71,7 @@ export async function updateApiKey(
     method: "PATCH",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${(await getAccessToken()).accessToken}`,
+      Authorization: `Bearer ${await getAccessTokenOrLogout()}`,
     },
     body: JSON.stringify({
       label: update.name ?? null,
@@ -86,7 +86,7 @@ export async function revokeApiKey(appId: string, siteKey: string) {
   await fetch(`${env.GOTCHA_ORIGIN}/api/console/${appId}/api-key/${siteKey}`, {
     method: "DELETE",
     headers: {
-      Authorization: `Bearer ${(await getAccessToken()).accessToken}`,
+      Authorization: `Bearer ${await getAccessTokenOrLogout()}`,
     },
   });
 
@@ -129,7 +129,7 @@ export async function addChallengeToApiKeyPool(
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${(await getAccessToken()).accessToken}`,
+        Authorization: `Bearer ${await getAccessTokenOrLogout()}`,
       },
       body: JSON.stringify({
         challenge_url: challengeUrl,
@@ -151,7 +151,7 @@ export async function removeChallengeToApiKeyPool(
       method: "DELETE",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${(await getAccessToken()).accessToken}`,
+        Authorization: `Bearer ${await getAccessTokenOrLogout()}`,
       },
       body: JSON.stringify({
         challenge_url: challengeUrl,

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -1,0 +1,23 @@
+import { getAccessToken, AccessTokenError } from "@auth0/nextjs-auth0";
+import { redirect } from "next/navigation";
+
+/**
+ * Wraps Auth0's getAccessToken(). If the access token has expired and no
+ * refresh token is available, forces the user through logout so the UI
+ * state stays in sync with the actual auth state (otherwise the session
+ * cookie lingers and the user appears logged in while backend calls fail).
+ */
+export async function getAccessTokenOrLogout(): Promise<string> {
+  try {
+    const { accessToken } = await getAccessToken();
+    if (!accessToken) {
+      redirect("/api/auth/logout");
+    }
+    return accessToken;
+  } catch (err) {
+    if (err instanceof AccessTokenError) {
+      redirect("/api/auth/logout");
+    }
+    throw err;
+  }
+}

--- a/src/lib/server/challenge-preferences.ts
+++ b/src/lib/server/challenge-preferences.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { revalidateTag, unstable_cache } from "next/cache";
-import { getAccessToken } from "@auth0/nextjs-auth0";
+import { getAccessTokenOrLogout } from "./auth";
 import { ChallengePreferences } from "./types";
 import env from "./env";
 
@@ -42,7 +42,7 @@ export async function updateChallengePreferences(
       method: "PATCH",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${(await getAccessToken()).accessToken}`,
+        Authorization: `Bearer ${await getAccessTokenOrLogout()}`,
       },
       body: JSON.stringify({
         width: update.width,

--- a/src/lib/server/console.ts
+++ b/src/lib/server/console.ts
@@ -2,7 +2,7 @@
 
 import { revalidateTag, unstable_cache } from "next/cache";
 import { Application } from "./types";
-import { getAccessToken } from "@auth0/nextjs-auth0";
+import { getAccessTokenOrLogout } from "./auth";
 import env from "./env";
 
 export const getApplications = unstable_cache(
@@ -35,7 +35,7 @@ export async function createApplication(name?: string) {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${(await getAccessToken()).accessToken}`,
+      Authorization: `Bearer ${await getAccessTokenOrLogout()}`,
     },
     body: JSON.stringify({
       label: name ?? "New Application",
@@ -49,7 +49,7 @@ export async function deleteApplication(id: string) {
   await fetch(`${env.GOTCHA_ORIGIN}/api/console/${id}`, {
     method: "DELETE",
     headers: {
-      Authorization: `Bearer ${(await getAccessToken()).accessToken}`,
+      Authorization: `Bearer ${await getAccessTokenOrLogout()}`,
     },
   });
 
@@ -68,7 +68,7 @@ export async function updateApplication(
     method: "PATCH",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${(await getAccessToken()).accessToken}`,
+      Authorization: `Bearer ${await getAccessTokenOrLogout()}`,
     },
     body: JSON.stringify({
       label: updateApp.name ?? null,


### PR DESCRIPTION
## Summary
- Adds `getAccessTokenOrLogout()` helper in `src/lib/server/auth.ts` that wraps Auth0's `getAccessToken()` and redirects to `/api/auth/logout` when the access token has expired (`AccessTokenError`) or is missing
- Replaces all direct `getAccessToken()` calls in server components and server actions with the new wrapper
- Fixes a UX bug where the session cookie could outlive the access token, leaving the user *appearing* logged in while every backend call failed with `ERR_EXPIRED_ACCESS_TOKEN`

## Behavior
**Before:** Access token expires → user sees dashboard but any action/navigation crashes with `ERR_EXPIRED_ACCESS_TOKEN`.

**After:** Access token expires → next page load or action transparently logs the user out and returns them to the public home page, where they can log in fresh.

## Test plan
- [ ] With a valid session, confirm pages and actions still work
- [ ] Simulate expired access token (shorten Auth0 access token lifetime, or manually clear it), then visit `/console` and verify user is redirected through `/api/auth/logout`
- [ ] Verify server-action mutations (generate key, update label, update domains, save preferences) also trigger logout on expired token

🤖 Generated with [Claude Code](https://claude.com/claude-code)